### PR TITLE
Lists

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,6 +3,34 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "locks (exec create list code)",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/target/debug/locks.exe",
+      "args": [
+        "exec",
+        "[10, 20, 30];"
+      ],
+      "stopAtEntry": false,
+      "cwd": "${fileDirname}",
+      "environment": [],
+      "console": "externalTerminal"
+    },
+    {
+      "name": "locks (debugging segfault)",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/target/debug/locks.exe",
+      "args": [
+        "run",
+        "./res/examples/list/list_expression_statement.locks"
+      ],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "console": "externalTerminal"
+    },
+    {
       "type": "extensionHost",
       "request": "launch",
       "name": "VS Code Language Extension",

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ With the syntax and implementation changes so far the Locks language has divered
   - Class method declarations require `fn` like functions
   - Setting undeclared fields on classes will generate an error
   - Class inheritence: `class Child : Parent {}` -> `class Child extends Parent {}`
+  - Lists: `[1, 2, 3]`, `arr[0]`, `arr[0] = 123`
 - [Dockerize](Dockerfile) the Locks binary executable
 - Implemented a [VS Code Extension](vsc)
   - Integrates the existing [language server](src/lsp.rs) to display parsing/compiler errors

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ fn main() {
         .expect("failed to process LALRPOP grammar");
 
     if cfg!(test) {
-        for path in ["res/examples/**/*.lox", "res/benchmarks/**/*.lox"] {
+        for path in ["res/examples/**/*.locks", "res/benchmarks/**/*.locks"] {
             build_deps::rerun_if_changed_paths(path).expect("could not read path");
         }
     }

--- a/playground/src/pages/docs.tsx
+++ b/playground/src/pages/docs.tsx
@@ -143,6 +143,11 @@ const Docs: React.FC = () => (
               Class Field/Method Index Access
             </Link>
           </li>
+          <li className="nav-item">
+            <Link className="nav-link" to="#lists ">
+              Lists
+            </Link>
+          </li>
         </ul>
         <DocCard
           title="Example"
@@ -445,6 +450,16 @@ const Docs: React.FC = () => (
             'print greeter.greet("World"); // out: Hello World!!!',
           ]}
           height="400px"
+        />
+        <DocCard
+          title="Lists"
+          anchor="lists"
+          code={[
+            'var list = [10, 20, 30];',
+            'var last = list[2];',
+            'print last; // out: 30',
+          ]}
+          height="100px"
         />
 
         <DocCard

--- a/playground/src/pages/docs.tsx
+++ b/playground/src/pages/docs.tsx
@@ -451,16 +451,6 @@ const Docs: React.FC = () => (
           ]}
           height="400px"
         />
-        <DocCard
-          title="Lists"
-          anchor="lists"
-          code={[
-            'var list = [10, 20, 30];',
-            'var last = list[2];',
-            'print last; // out: 30',
-          ]}
-          height="100px"
-        />
 
         <DocCard
           title="Class Field/Method Index Access"
@@ -484,6 +474,21 @@ const Docs: React.FC = () => (
           ]}
           height="275px"
         />
+
+        <DocCard
+          title="Lists"
+          anchor="lists"
+          code={[
+            'let list = [10, 20, 30];',
+            'let last = list[2];',
+            'print last; // out: 30',
+            'list[1] = list[1] * 2;',
+            'print list[1]; // out: 40',
+          ]}
+          height="100px"
+        >
+          Lists can store a dynamic number of mixed types in a collection.
+        </DocCard>
 
         <div className="shadow rounded p-3 vstack gap-3">
           <h2 id="errors">

--- a/res/examples/list/expression_statements.locks
+++ b/res/examples/list/expression_statements.locks
@@ -1,0 +1,5 @@
+print [1, 2, 5]; // out: <list length=3>
+print []; // out: <list length=0>
+print [100, 200, 300][0]; // out: 100
+
+//print len([20, 30]);

--- a/res/examples/list/expression_statements.locks
+++ b/res/examples/list/expression_statements.locks
@@ -1,5 +1,3 @@
 print [1, 2, 5]; // out: <list length=3>
 print []; // out: <list length=0>
 print [100, 200, 300][0]; // out: 100
-
-//print len([20, 30]);

--- a/res/examples/list/get_index.locks
+++ b/res/examples/list/get_index.locks
@@ -1,0 +1,12 @@
+let a = ["a", "b"];
+
+print a[1]; // out: b
+
+let list = [100, 200, 300];
+
+print list[0]; // out: 100
+print list[1]; // out: 200
+print list[2]; // out: 300
+print list[3]; // out: IndexError: the length is 3 but the index is 3 (out of bounds)
+
+//print len([20, 30]);

--- a/res/examples/list/get_index.locks
+++ b/res/examples/list/get_index.locks
@@ -8,5 +8,3 @@ print list[0]; // out: 100
 print list[1]; // out: 200
 print list[2]; // out: 300
 print list[3]; // out: IndexError: the length is 3 but the index is 3 (out of bounds)
-
-//print len([20, 30]);

--- a/res/examples/list/get_index_on_bool.locks
+++ b/res/examples/list/get_index_on_bool.locks
@@ -1,0 +1,1 @@
+print true[0]; // out: TypeError: "bool" is not indexable

--- a/res/examples/list/get_index_on_class.locks
+++ b/res/examples/list/get_index_on_class.locks
@@ -1,0 +1,5 @@
+class Class {
+  
+}
+
+print Class[0]; // out: TypeError: "class" is not indexable

--- a/res/examples/list/get_index_on_class_instanitate_expression.locks
+++ b/res/examples/list/get_index_on_class_instanitate_expression.locks
@@ -1,0 +1,3 @@
+class Class {}
+
+print Class()[0]; // out: TypeError: "instance" is not indexable

--- a/res/examples/list/get_index_on_instance.locks
+++ b/res/examples/list/get_index_on_instance.locks
@@ -1,0 +1,5 @@
+class Class {}
+
+let c = Class();
+
+print c[0]; // out: TypeError: "instance" is not indexable

--- a/res/examples/list/get_index_on_instance_list_field.locks
+++ b/res/examples/list/get_index_on_instance_list_field.locks
@@ -1,0 +1,9 @@
+class Class {
+  let values;
+  
+  fn init() {
+    this.values = [10, 20, 30];
+  }
+}
+
+print Class().values[0]; // out: 10

--- a/res/examples/list/get_index_on_list_returned_from_function.locks
+++ b/res/examples/list/get_index_on_list_returned_from_function.locks
@@ -1,0 +1,5 @@
+fn function() {
+  return [4, 5 ,6];
+}
+
+print function()[0]; // out: 4

--- a/res/examples/list/get_index_on_nil copy.locks
+++ b/res/examples/list/get_index_on_nil copy.locks
@@ -1,0 +1,1 @@
+print nil[0]; // out: TypeError: "nil" is not indexable

--- a/res/examples/list/get_index_on_nil.locks
+++ b/res/examples/list/get_index_on_nil.locks
@@ -1,0 +1,1 @@
+print nil[0]; // out: TypeError: "nil" is not indexable

--- a/res/examples/list/get_index_on_number.locks
+++ b/res/examples/list/get_index_on_number.locks
@@ -1,0 +1,1 @@
+print 0[0]; // out: TypeError: "number" is not indexable

--- a/res/examples/list/get_index_on_string.locks
+++ b/res/examples/list/get_index_on_string.locks
@@ -1,0 +1,3 @@
+let string = "foo";
+
+print string[0]; // out: TypeError: "string" is not indexable

--- a/res/examples/list/get_index_with_empty_index.locks
+++ b/res/examples/list/get_index_with_empty_index.locks
@@ -1,0 +1,1 @@
+print [10, 20, 30][]; // out: SyntaxError: unexpected "]"

--- a/res/examples/list/get_index_with_non_number_index.locks
+++ b/res/examples/list/get_index_with_non_number_index.locks
@@ -1,0 +1,3 @@
+let list = [1, 2];
+
+print list["b"]; // out: AttributeError: "list" object has no attribute "b"

--- a/res/examples/list/nested_lists.locks
+++ b/res/examples/list/nested_lists.locks
@@ -1,0 +1,3 @@
+let list = [10, 20, [30]];
+let last = list[2][0];
+print last; // out: 30

--- a/res/examples/list/set_index.locks
+++ b/res/examples/list/set_index.locks
@@ -1,0 +1,13 @@
+let list = [100, 200, 300];
+
+print list[0]; // out: 100
+print list[1]; // out: 200
+print list[2]; // out: 300
+
+list[1] = 400;
+
+print list[0]; // out: 100
+print list[1]; // out: 400
+print list[2]; // out: 300
+
+list[3] = 1000; // out: IndexError: the length is 3 but the index is 3 (out of bounds)

--- a/res/grammar.lalrpop
+++ b/res/grammar.lalrpop
@@ -119,6 +119,8 @@ ExprAssign = {
             },
             value,
         })),
+    <target:Spanned<ExprCall>> "[" <index:number> "]" "=" <value:ExprS> =>
+        ast::Expr::SetIndex(Box::new(ast::ExprSetIndex {<>})),
     <object:Spanned<ExprCall>> "." <name:identifier> "=" <value:ExprS> =>
         ast::Expr::Set(Box::new(ast::ExprSet { <> })),
     <object:Spanned<ExprCall>> "[" <name:identifier> "]" "=" <value:ExprS> =>
@@ -180,6 +182,8 @@ ExprCall: ast::Expr = {
         ast::Expr::Get(Box::new(ast::ExprGet { <> })),
     <object:Spanned<ExprCall>> "[" <name:identifier> "]" =>
         ast::Expr::Get(Box::new(ast::ExprGet { <> })),
+    <target:Spanned<ExprCall>> "[" <index:number> "]" =>
+        ast::Expr::GetIndex(Box::new(ast::ExprGetIndex {<>})),
     "super" "." <name:identifier> =>
         ast::Expr::Super(ast::ExprSuper {
             super_: ast::Identifier {
@@ -204,6 +208,11 @@ ExprCall: ast::Expr = {
             },
             name,
         }),
+    ExprList,
+}
+
+ExprList: ast::Expr = {
+    "[" <values:Args> "]" => ast::Expr::Literal(ast::ExprLiteral::List(<>)),
     ExprPrimary,
 }
 
@@ -217,7 +226,7 @@ ExprPrimary: ast::Expr = {
 
     // Variables
     ExprIdentifier,
-    ExprThis,
+    ExprThis,    
 
     // Grouping
     "(" <Expr> ")",
@@ -238,13 +247,16 @@ ExprThis: ast::Expr = "this" => ast::Expr::Identifier(ast::ExprIdentifier {
     }
 });
 
-// Utilities
+/// Utilities
+
+// Expr + Span (start..end)
 Spanned<T>: ast::Spanned<T> = <l:@L> <t:T> <r:@R> => (t, l..r);
 
 Function: ast::StmtFn =
     <name:identifier> "(" <params:Params> ")" <body:StmtBlockInternal> =>
         ast::StmtFn { <> };
 
+// Comma separated list of string parameters a function/method takes
 Params: Vec<String> = {
     <first:identifier> <mut params:("," <identifier>)*> => {
         params.insert(0, first);
@@ -253,6 +265,7 @@ Params: Vec<String> = {
     () => Vec::new(),
 };
 
+// Comma separated list of expression arugments passed to a function/method call
 Args: Vec<ast::ExprS> = {
     <first:ExprS> <mut args:("," <ExprS>)*> => {
         args.insert(0, first);

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -94,6 +94,7 @@ pub struct StmtReturn {
     pub value: Option<ExprS>,
 }
 
+/// Statement that sets `var.name` to `value`
 #[derive(Clone, Debug, PartialEq)]
 pub struct StmtAssign {
     pub identifier: Identifier,
@@ -111,6 +112,8 @@ pub enum Expr {
     Assign(Box<ExprAssign>),
     Call(Box<ExprCall>),
     Get(Box<ExprGet>),
+    GetIndex(Box<ExprGetIndex>),
+    SetIndex(Box<ExprSetIndex>),
     Infix(Box<ExprInfix>),
     Literal(ExprLiteral),
     Prefix(Box<ExprPrefix>),
@@ -131,6 +134,8 @@ impl Debug for Expr {
             Self::Set(arg0) => f.write_fmt(format_args!("{:#?}", arg0)),
             Self::Super(arg0) => f.write_fmt(format_args!("{:#?}", arg0)),
             Self::Identifier(arg0) => f.write_fmt(format_args!("{:#?}", arg0)),
+            Self::GetIndex(arg0) => f.write_fmt(format_args!("{:#?}", arg0)),
+            Self::SetIndex(arg0) => f.write_fmt(format_args!("{:#?}", arg0)),
         }
     }
 }
@@ -138,6 +143,19 @@ impl Debug for Expr {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExprAssign {
     pub identifier: Identifier,
+    pub value: ExprS,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprGetIndex {
+    pub target: ExprS,
+    pub index: f64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprSetIndex {
+    pub target: ExprS,
+    pub index: f64,
     pub value: ExprS,
 }
 
@@ -159,6 +177,7 @@ pub enum ExprLiteral {
     Nil,
     Number(f64),
     String(String),
+    List(Vec<ExprS>),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/vm/disassembler.rs
+++ b/src/vm/disassembler.rs
@@ -126,6 +126,9 @@ impl<'a> Disassembler<'a> {
             op::RETURN => self.disassemble_op_simple("OP_RETURN"),
             op::CLASS => self.disassemble_op_constant("OP_CLASS", op_idx),
             op::INHERIT => self.disassemble_op_simple("OP_INHERIT"),
+            op::CREATE_LIST => self.disassemble_op_byte("OP_CREATE_LIST", op_idx),
+            op::GET_INDEX => self.disassemble_op_simple("OP_GET_INDEX"),
+            op::SET_INDEX => self.disassemble_op_simple("OP_SET_INDEX"),
             op::METHOD => self.disassemble_op_constant("OP_METHOD", op_idx),
             op::FIELD => self.disassemble_op_constant("OP_FIELD", op_idx),
             byte => self.disassemble_op_simple(&format!("OP_UNKNOWN({byte:#X})")),
@@ -206,6 +209,42 @@ mod tests {
     }}
 
     assert_disassembly! {
+        list_get_index: (
+            "[1, 2][0];",
+            "\
+            0000 OP_CONSTANT         0 == '1'\n\
+            0002 OP_CONSTANT         1 == '2'\n\
+            0004 OP_CREATE_LIST      2\n\
+            0006 OP_CONSTANT         2 == '0'\n\
+            0008 OP_GET_INDEX\n\
+            0009 OP_POP\n\
+            0010 OP_NIL\n\
+            0011 OP_RETURN\n"
+        ),
+        list_set_index: (
+            "[1, 2][0] = 2;",
+            "\
+            0000 OP_CONSTANT         0 == '1'\n\
+            0002 OP_CONSTANT         1 == '2'\n\
+            0004 OP_CREATE_LIST      2\n\
+            0006 OP_CONSTANT         2 == '0'\n\
+            0008 OP_CONSTANT         1 == '2'\n\
+            0010 OP_SET_INDEX\n\
+            0011 OP_POP\n\
+            0012 OP_NIL\n\
+            0013 OP_RETURN\n"
+        ),
+        list: (
+            "[1, 2, 5];",
+            "\
+            0000 OP_CONSTANT         0 == '1'\n\
+            0002 OP_CONSTANT         1 == '2'\n\
+            0004 OP_CONSTANT         2 == '5'\n\
+            0006 OP_CREATE_LIST      3\n\
+            0008 OP_POP\n\
+            0009 OP_NIL\n\
+            0010 OP_RETURN\n"
+        ),
         assignment_string: (
             "let a = \"Hello\";",
             "\

--- a/src/vm/gc.rs
+++ b/src/vm/gc.rs
@@ -69,6 +69,14 @@ impl Gc {
                 }
                 ObjectType::Native => {}
                 ObjectType::String => {}
+                ObjectType::List => {
+                    let list = unsafe { object.list };
+                    let values = unsafe { &(*list).values };
+
+                    for &value in values {
+                        self.mark(value);
+                    }
+                }
                 ObjectType::Upvalue => {
                     let upvalue = unsafe { object.upvalue };
                     self.mark(unsafe { (*upvalue).closed });

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -21,13 +21,13 @@ use hashbrown::HashMap;
 use rustc_hash::FxHasher;
 
 use crate::error::{
-    AttributeError, Error, ErrorS, IoError, NameError, OverflowError, Result, TypeError,
+    AttributeError, Error, ErrorS, IndexError, IoError, NameError, OverflowError, Result, TypeError,
 };
 use crate::vm::allocator::GLOBAL;
 use crate::vm::gc::GcAlloc;
 use crate::vm::object::{
     Native, ObjectBoundMethod, ObjectClass, ObjectClosure, ObjectFunction, ObjectInstance,
-    ObjectNative, ObjectString, ObjectType, ObjectUpvalue,
+    ObjectList, ObjectNative, ObjectString, ObjectType, ObjectUpvalue,
 };
 use crate::vm::value::Value;
 
@@ -191,6 +191,9 @@ impl VM {
                 op::INHERIT => self.op_inherit(),
                 op::METHOD => self.op_method(),
                 op::FIELD => self.op_field(),
+                op::CREATE_LIST => self.op_create_list(),
+                op::GET_INDEX => self.op_get_index(),
+                op::SET_INDEX => self.op_set_index(),
                 _ => util::unreachable(),
             }?;
 
@@ -209,6 +212,84 @@ impl VM {
             self.frame.stack, self.stack_top,
             "VM finished executing but stack is not empty"
         );
+        Ok(())
+    }
+
+    fn op_create_list(&mut self) -> Result<()> {
+        let length = self.read_u8();
+
+        let mut values = vec![];
+
+        for _ in 0..length {
+            let value = self.pop();
+
+            values.push(value);
+        }
+
+        values.reverse();
+
+        let list = self.gc.alloc(ObjectList::new(values));
+        let value = list.into();
+
+        self.push(value);
+
+        Ok(())
+    }
+
+    fn op_get_index(&mut self) -> Result<()> {
+        let index = self.pop();
+        let target = self.pop();
+
+        if target.is_object() {
+            if target.as_object().type_() == ObjectType::List {
+                let list = unsafe { &(*target.as_object().list) };
+                let list_idx = index.as_number() as usize;
+
+                if list_idx >= list.values.len() {
+                    return self.err(IndexError::OutOfBounds {
+                        wanted_index: list_idx,
+                        length: list.values.len(),
+                    });
+                }
+
+                let value = list.values[list_idx];
+                self.push(value);
+            } else {
+                return self.err(TypeError::NotIndexable {
+                    type_: target.as_object().type_().to_string(),
+                });
+            }
+        } else {
+            return self.err(TypeError::NotIndexable { type_: target.type_().to_string() });
+        }
+
+        Ok(())
+    }
+
+    fn op_set_index(&mut self) -> Result<()> {
+        let value = self.pop();
+        let index = self.pop();
+        let target = self.pop();
+
+        if target.is_object() {
+            if target.as_object().type_() == ObjectType::List {
+                let list = unsafe { &mut (*target.as_object().list) };
+                let list_idx = index.as_number() as usize;
+
+                if list_idx >= list.values.len() {
+                    return self.err(IndexError::OutOfBounds {
+                        wanted_index: list_idx,
+                        length: list.values.len(),
+                    });
+                }
+
+                list.values[list_idx] = value;
+                self.push(value);
+            } else {
+                return self.err(TypeError::NotIndexable { type_: target.type_().to_string() });
+            }
+        }
+
         Ok(())
     }
 
@@ -852,9 +933,38 @@ impl VM {
                     });
                 }
                 util::now().into()
-            }
+            } // Native::Length => {
+              //     if arg_count != 1 {
+              //         return self.err(TypeError::ArityMismatch {
+              //             name: "len".to_string(),
+              //             exp_args: 1,
+              //             got_args: arg_count,
+              //         });
+              //     }
+
+              //     let arg = self.pop();
+
+              //     // let obj = arg.as_object();
+
+              //     // let length = match obj.type_() {
+              //     //     ObjectType::BoundMethod => Value::NIL,
+              //     //     ObjectType::Class => Value::NIL,
+              //     //     ObjectType::Closure => Value::NIL,
+              //     //     ObjectType::Function => Value::NIL,
+              //     //     ObjectType::Native => Value::NIL,
+              //     //     ObjectType::Instance => Value::NIL,
+              //     //     ObjectType::String => Value::NIL,
+              //     //     ObjectType::List => Value::from(0.0),
+              //     //     ObjectType::Upvalue => Value::from(0.0),
+              //     // };
+
+              //     // length
+              //     arg
+              // }
         };
+
         self.push(value);
+
         Ok(())
     }
 
@@ -980,6 +1090,10 @@ impl Default for VM {
         let clock_string = gc.alloc("clock");
         let clock_native = Value::from(gc.alloc(ObjectNative::new(Native::Clock)));
         globals.insert(clock_string, clock_native);
+
+        // let len_string = gc.alloc("len");
+        // let len_native = Value::from(gc.alloc(ObjectNative::new(Native::Length)));
+        // globals.insert(len_string, len_native);
 
         let init_string = gc.alloc("init");
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -933,34 +933,7 @@ impl VM {
                     });
                 }
                 util::now().into()
-            } // Native::Length => {
-              //     if arg_count != 1 {
-              //         return self.err(TypeError::ArityMismatch {
-              //             name: "len".to_string(),
-              //             exp_args: 1,
-              //             got_args: arg_count,
-              //         });
-              //     }
-
-              //     let arg = self.pop();
-
-              //     // let obj = arg.as_object();
-
-              //     // let length = match obj.type_() {
-              //     //     ObjectType::BoundMethod => Value::NIL,
-              //     //     ObjectType::Class => Value::NIL,
-              //     //     ObjectType::Closure => Value::NIL,
-              //     //     ObjectType::Function => Value::NIL,
-              //     //     ObjectType::Native => Value::NIL,
-              //     //     ObjectType::Instance => Value::NIL,
-              //     //     ObjectType::String => Value::NIL,
-              //     //     ObjectType::List => Value::from(0.0),
-              //     //     ObjectType::Upvalue => Value::from(0.0),
-              //     // };
-
-              //     // length
-              //     arg
-              // }
+            }
         };
 
         self.push(value);

--- a/src/vm/object.rs
+++ b/src/vm/object.rs
@@ -290,14 +290,12 @@ impl ObjectNative {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Native {
     Clock,
-    // Length,
 }
 
 impl Display for Native {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Native::Clock => write!(f, "clock"),
-            // Native::Length => write!(f, "len"),
         }
     }
 }

--- a/src/vm/object.rs
+++ b/src/vm/object.rs
@@ -21,6 +21,7 @@ pub union Object {
     pub instance: *mut ObjectInstance,
     pub native: *mut ObjectNative,
     pub string: *mut ObjectString,
+    pub list: *mut ObjectList,
     pub upvalue: *mut ObjectUpvalue,
 }
 
@@ -69,6 +70,11 @@ impl Object {
                     let _ = Box::from_raw(self.string);
                 };
             }
+            ObjectType::List => {
+                unsafe {
+                    let _ = Box::from_raw(self.list);
+                };
+            }
             ObjectType::Upvalue => {
                 unsafe {
                     let _ = Box::from_raw(self.upvalue);
@@ -89,7 +95,8 @@ impl Display for Object {
         match self.type_() {
             ObjectType::BoundMethod => {
                 write!(f, "<bound method {}>", unsafe {
-                    (*(*(*(*self.bound_method).closure).function).name).value
+                    let value = (*(*(*(*self.bound_method).closure).function).name).value;
+                    value
                 })
             }
             ObjectType::Class => {
@@ -112,6 +119,11 @@ impl Display for Object {
             }
             ObjectType::Native => write!(f, "<native {}>", unsafe { (*self.native).native }),
             ObjectType::String => write!(f, "{}", unsafe { (*self.string).value }),
+            ObjectType::List => {
+                let length = unsafe { (*self.list).values.len() };
+                let v = format!("<list length={}>", length);
+                write!(f, "{}", v)
+            }
             ObjectType::Upvalue => write!(f, "<upvalue>"),
         }
     }
@@ -135,6 +147,7 @@ impl_from_object!(function, ObjectFunction);
 impl_from_object!(instance, ObjectInstance);
 impl_from_object!(native, ObjectNative);
 impl_from_object!(string, ObjectString);
+impl_from_object!(list, ObjectList);
 impl_from_object!(upvalue, ObjectUpvalue);
 
 impl PartialEq for Object {
@@ -160,6 +173,7 @@ pub enum ObjectType {
     Native,
     Instance,
     String,
+    List,
     Upvalue,
 }
 
@@ -173,6 +187,7 @@ impl Display for ObjectType {
             ObjectType::Instance => write!(f, "instance"),
             ObjectType::Native => write!(f, "native"),
             ObjectType::String => write!(f, "string"),
+            ObjectType::List => write!(f, "list"),
             ObjectType::Upvalue => write!(f, "upvalue"),
         }
     }
@@ -275,12 +290,14 @@ impl ObjectNative {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Native {
     Clock,
+    // Length,
 }
 
 impl Display for Native {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Native::Clock => write!(f, "clock"),
+            // Native::Length => write!(f, "len"),
         }
     }
 }
@@ -296,6 +313,20 @@ impl ObjectString {
     pub fn new(value: &'static str) -> Self {
         let common = ObjectCommon { type_: ObjectType::String, is_marked: false };
         Self { common, value }
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct ObjectList {
+    pub common: ObjectCommon,
+    pub values: Vec<Value>,
+}
+
+impl ObjectList {
+    pub fn new(values: Vec<Value>) -> Self {
+        let common = ObjectCommon { type_: ObjectType::List, is_marked: false };
+        Self { common, values }
     }
 }
 

--- a/src/vm/op.rs
+++ b/src/vm/op.rs
@@ -84,5 +84,8 @@ iota! {
     CLASS,
     INHERIT,
     METHOD,
-    FIELD
+    FIELD,
+    CREATE_LIST,
+    GET_INDEX,
+    SET_INDEX
 }

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -33,7 +33,9 @@ impl Display for Value {
         } else if self.is_number() {
             write!(f, "{}", self.as_number())
         } else if self.is_object() {
-            write!(f, "{}", self.as_object())
+            let o = self.as_object();
+            let v = format!("{}", o);
+            write!(f, "{}", v)
         } else {
             util::unreachable()
         }


### PR DESCRIPTION
# Summary 

Implement lists #11 * in the language

- Literal syntax: `[1, 2, "strings too"]`
- Index/subscript access syntax `arr[1]` as well as setting `arr[0] = 123`
- Works with instance field index access syntax

\* There will be a difference between lists and arrays at some point